### PR TITLE
Respect PI_CODING_AGENT_DIR for code preview settings

### DIFF
--- a/src/settings-store.ts
+++ b/src/settings-store.ts
@@ -1,21 +1,31 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
-import { codePreviewSettings, normalizeSettings, type CodePreviewSettings } from "./settings.ts";
+import { type CodePreviewSettings, codePreviewSettings, normalizeSettings } from "./settings.ts";
 
 export function getSettingsPath(): string {
+  return join(getAgentConfigDir(), "code-previews.json");
+}
+
+function getAgentConfigDir(): string {
+  return process.env.PI_CODING_AGENT_DIR || join(homedir(), ".pi", "agent");
+}
+
+function getLegacySettingsPath(): string {
   return join(homedir(), ".pi", "agent", "code-previews.json");
 }
 
 export async function loadSettingsFromDisk(): Promise<CodePreviewSettings | undefined> {
   let loaded = false;
   let effective = codePreviewSettings;
-  for (const settingsPath of [
+  const settingsPaths = [
     join(homedir(), ".pi", "settings.json"),
     join(homedir(), ".pi", "agent", "settings.json"),
     join(process.cwd(), ".pi", "settings.json"),
+    getLegacySettingsPath(),
     getSettingsPath(),
-  ]) {
+  ];
+  for (const settingsPath of new Set(settingsPaths)) {
     try {
       const content = await readFile(settingsPath, "utf8");
       effective = normalizeSettings(extractCodePreviewSettings(JSON.parse(content)), effective);

--- a/tests/settings-store.test.ts
+++ b/tests/settings-store.test.ts
@@ -1,7 +1,21 @@
 import assert from "node:assert/strict";
-import { test } from "vitest";
+import { join } from "node:path";
+import { afterEach, test } from "vitest";
 import { defaultCodePreviewSettings } from "../src/settings.ts";
-import { extractCodePreviewSettings } from "../src/settings-store.ts";
+import { extractCodePreviewSettings, getSettingsPath } from "../src/settings-store.ts";
+
+const originalPiCodingAgentDir = process.env.PI_CODING_AGENT_DIR;
+
+afterEach(() => {
+  if (originalPiCodingAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+  else process.env.PI_CODING_AGENT_DIR = originalPiCodingAgentDir;
+});
+
+test("getSettingsPath respects PI_CODING_AGENT_DIR", () => {
+  process.env.PI_CODING_AGENT_DIR = "/tmp/pi-config";
+
+  assert.equal(getSettingsPath(), join("/tmp/pi-config", "code-previews.json"));
+});
 
 test("extractCodePreviewSettings accepts nested, prefixed, and saved raw settings", () => {
   assert.deepEqual(extractCodePreviewSettings({ codePreview: { readCollapsedLines: 20 } }), {
@@ -11,8 +25,10 @@ test("extractCodePreviewSettings accepts nested, prefixed, and saved raw setting
     readCollapsedLines: 30,
   });
   assert.deepEqual(
-    extractCodePreviewSettings({ ...defaultCodePreviewSettings, readCollapsedLines: 40 })
-      .readCollapsedLines,
+    extractCodePreviewSettings({
+      ...defaultCodePreviewSettings,
+      readCollapsedLines: 40,
+    }).readCollapsedLines,
     40,
   );
   assert.deepEqual(extractCodePreviewSettings({ theme: "dark" }), {});


### PR DESCRIPTION
## Summary

- Store code preview settings under `PI_CODING_AGENT_DIR` when it is set.
- Keep reading the legacy `~/.pi/agent/code-previews.json` file as a fallback.
- Add a test for the resolved settings path.

Closes #4.

## Tests

```bash
npm run check
npm test
```