### PR TITLE
fix: replace prepare with prepack to fix git install

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "word:spans": "tsx bench/word-emphasis-spans.ts",
     "bench:recommended": "npm run bench:diff-wrap && npm run bench:edit-rendering && npm run bench:write-diff && npm run bench:word-pathology",
     "test": "vitest run",
-    "prepare": "npm run build",
+    "prepack": "npm run build",
     "prepublishOnly": "npm run check && npm test",
     "pack:dry": "npm pack --dry-run"
   },


### PR DESCRIPTION
## Problem

Installing from git via `pi install git:github.com/mattleong/pi-code-previews` fails with:

```
> pi-code-previews@0.1.25 prepare
> npm run build

> pi-code-previews@0.1.25 build
> tsdown

sh: tsdown: command not found
```

`pi install` runs `npm install --omit=dev`, which skips devDependencies. The `prepare` lifecycle script still fires and tries to run `tsdown`, but `tsdown` is a devDependency and isn't installed.

## Fix

Replace the `prepare` script with `prepack`. The `prepack` lifecycle hook only runs before `npm pack` / `npm publish`, **not** during `npm install`. This means:

- **npm publish** still works — `prepack` builds `dist/` before the tarball is created, so the published package contains the built output
- **git install via pi** no longer triggers a build, avoiding the `tsdown: command not found` error
- **pi loads the extension** via jiti from `./index.ts` at runtime, so `dist/` is never needed at git-install time

## Why not other approaches?

| Approach | Drawback |
|---|---|
| Move `tsdown` to `dependencies` | Semantically wrong (build tool ≠ runtime dep), bloats installs |
| Conditional `prepare` | Complex, noisy |
| Commit `dist/` to repo | Messy git diffs, merge conflicts in generated files |
| `npx tsdown` in build script | Defeats `--omit=dev`, adds latency |

Closes #7