### PR TITLE
fix(diff): remove uncolored gap at right edge of diff background

### DIFF
--- a/src/diff/background.ts
+++ b/src/diff/background.ts
@@ -22,9 +22,10 @@ export function diffLineBg(
   const bg = diffBackground(kind);
   if (!bg) return line;
   const coloredLine = line
+    .replace(/\x1b\[0m/g, `\x1b[0m${bg}`)
     .replace(/\x1b\[39m/g, `\x1b[39m${bg}`)
     .replace(/\x1b\[49m/g, `\x1b[49m${bg}`);
-  return `${bg}${coloredLine}\x1b[49m`;
+  return `${bg}${coloredLine}`;
 }
 
 function fallbackDiffBg(kind: DiffLineKind, intensity: "subtle" | "medium"): string {

--- a/src/diff/index.spec.ts
+++ b/src/diff/index.spec.ts
@@ -9,6 +9,7 @@ import {
   renderSyntaxHighlightedDiff,
   summarizeDiff,
 } from "./index";
+import { createDiffBackgroundResolver, diffLineBg } from "./background";
 import { wordEmphasisTelemetry } from "../testing/word-emphasis-telemetry";
 import { changedRanges, changedRangesWithConfidence } from "./word/emphasis";
 
@@ -87,12 +88,38 @@ test("diff background reaches box right padding without exceeding child width", 
   assert.match(line, /\x1b\[48;2;10;42;26m[^\n]* \x1b\[49m/);
 });
 
-test("diff background rows reset their own background", () => {
+test("diff background rows do NOT reset their own background", () => {
   const row = new FullWidthDiffText(
     renderPlainDiff("+1 short", testTheme(), 1),
     testTheme(),
   ).render(20)[0];
-  assert.match(row ?? "", /\x1b\[48;2;10;42;26m[^\n]*\x1b\[49m$/);
+  // diff bg extends to end without trailing \x1b[49m; parent containers handle bg reset
+  assert.match(row ?? "", /\x1b\[48;2;10;42;26m[^\n]*$/);
+  assert.doesNotMatch(row ?? "", /\x1b\[49m$/);
+});
+
+test("diff background reaches right padding even after truncateToWidth reset", () => {
+  const theme: ReturnType<typeof testTheme> = {
+    bold: (text: string) => `\x1b[1m${text}\x1b[22m`,
+    fg: (key: string, text: string) => {
+      const colors: Record<string, string> = {
+        toolDiffAdded: "\x1b[38;2;100;200;100m",
+      };
+      const c = colors[key] ?? "";
+      return c ? `${c}${text}\x1b[39m` : text;
+    },
+  };
+  const bg = createDiffBackgroundResolver(theme)("add")!;
+
+  // Simulate what happens when truncateToWidth appends 0m then the line is boxed
+  const line = theme.fg("toolDiffAdded", "+ 33 │ ") + `\x1b[38;2;180;120;50msome code\x1b[39m`;
+  const withBg = diffLineBg("add", line, createDiffBackgroundResolver(theme));
+  const truncated = withBg + "\x1b[0m";
+  const padding = " ".repeat(Math.max(0, 76 - visibleWidth(truncated)));
+  const framed = `${theme.fg("borderMuted", "│")} ${truncated}${padding} ${theme.fg("borderMuted", "│")}`;
+
+  // No uncolored gap before the border
+  assert.doesNotMatch(framed, /\x1b\[49m\x1b\[0m \x1b\[38/, "there should be no uncolored gap");
 });
 
 test("word emphasis pairs the most similar lines inside change blocks", () => {

--- a/src/preview/bordered-tool-call.ts
+++ b/src/preview/bordered-tool-call.ts
@@ -194,6 +194,14 @@ export class BorderedToolCall implements Component {
   private frameLine(line: string, innerWidth: number, border: (value: string) => string): string {
     const truncated = truncateToWidth(line, innerWidth, "");
     const padding = " ".repeat(Math.max(0, innerWidth - visibleWidth(truncated)));
+    // FullWidthDiffText diff lines have an active diff background that extends
+    // to the end (no trailing \x1b[49m). Let the diff bg cover padding and
+    // the right margin space, then reset bg right before the border │.
+    // For non-diff lines, RESET_ANSI goes before padding to clear attributes.
+    const diffBgPrefix = /^\x1b\[48;2;\d+;\d+;\d+m/.exec(truncated);
+    if (diffBgPrefix) {
+      return `${border("│")} ${truncated}${padding} \x1b[49m${border("│")}${RESET_ANSI}`;
+    }
     return `${border("│")} ${truncated}${RESET_ANSI}${padding} ${border("│")}`;
   }
 }


### PR DESCRIPTION
## Summary

Fixes an uncolored gap that appeared at the right edge of diff background coloring on added/removed lines.

| Before | After |
| - | - |
| <img width="1192" height="456" alt="image" src="https://github.com/user-attachments/assets/dad2ff4e-e3e9-4d52-a244-f8ccc8b43fd8" /> | <img width="1189" height="450" alt="image" src="https://github.com/user-attachments/assets/638d47e7-cb5b-4100-9ef7-bf0b5db331ce" /> |

Closes #12

## Root Cause

`diffLineBg` appended `\x1b[49m` (background reset) at the end of every diff line. When parent containers then added right padding spaces, those spaces sat after the reset with no active background — producing a visible uncolored gap.

This affected **both rendering modes**:

- **Box mode** (`toolCallBackground: "on"` — the default): `Box.bgFn` wraps the line with box background, but the diff's `\x1b[49m` prematurely resets all background, leaving trailing box padding uncolored
- **BorderedToolCall mode** (`toolCallBackground: "border"`): `frameLine`'s right margin space sits after `RESET_ANSI`, which resets the already-reset diff background, leaving the space uncolored

## Changes

### `src/diff/background.ts` — `diffLineBg`
1. Added `.replace(/\x1b\[0m/g, \x1b[0m${bg})` — re-injects diff background after full ANSI resets (from `truncateToWidth`)
2. Removed the trailing `\x1b[49m` — the diff background now stays active to the end of the line; parent containers handle the bg reset at the appropriate point

### `src/preview/bordered-tool-call.ts` — `frameLine`
Detects diff lines by checking if they start with a diff bg code (`\x1b[48;2;...m`). For diff lines, lets the active bg cover padding and the right margin space, then adds `\x1b[49m` right before the border `│`. For non-diff lines, the original `RESET_ANSI` + padding behavior is preserved.

### `src/diff/index.spec.ts`
- Updated test expectations: diff rows no longer end with `\x1b[49m`
- Added regression test verifying no uncolored gap after `truncateToWidth` resets