### PR TITLE
fix: keep aborted write previews queued until safe

### DIFF
--- a/src/diff/index.spec.ts
+++ b/src/diff/index.spec.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import type { Theme } from "@earendil-works/pi-coding-agent";
 import { Box, visibleWidth } from "@earendil-works/pi-tui";
 import { afterEach, beforeEach, test } from "vitest";
 import { codePreviewSettings, setCodePreviewSettings } from "../settings/index";
@@ -99,8 +100,8 @@ test("diff background rows do NOT reset their own background", () => {
 });
 
 test("diff background reaches right padding even after truncateToWidth reset", () => {
-  const theme: ReturnType<typeof testTheme> = {
-    bold: (text: string) => `\x1b[1m${text}\x1b[22m`,
+  const theme = {
+    ...testTheme(),
     fg: (key: string, text: string) => {
       const colors: Record<string, string> = {
         toolDiffAdded: "\x1b[38;2;100;200;100m",
@@ -108,8 +109,7 @@ test("diff background reaches right padding even after truncateToWidth reset", (
       const c = colors[key] ?? "";
       return c ? `${c}${text}\x1b[39m` : text;
     },
-  };
-  const bg = createDiffBackgroundResolver(theme)("add")!;
+  } as Theme;
 
   // Simulate what happens when truncateToWidth appends 0m then the line is boxed
   const line = theme.fg("toolDiffAdded", "+ 33 │ ") + `\x1b[38;2;180;120;50msome code\x1b[39m`;

--- a/src/write/preview-execution.spec.ts
+++ b/src/write/preview-execution.spec.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { withFileMutationQueue } from "@earendil-works/pi-coding-agent";
+import { test, vi } from "vitest";
+import { resolvePreviewPath } from "../paths/resolve";
+import { readExistingFileForPreview } from "./diff";
+import { executeWriteWithPreview } from "./preview-execution";
+
+vi.mock("node:fs/promises", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:fs/promises")>()),
+  mkdir: vi.fn(),
+  writeFile: vi.fn(),
+}));
+
+vi.mock("./diff", () => ({
+  readExistingFileForPreview: vi.fn(),
+}));
+
+test("aborted writes keep the file mutation queue locked until in-flight writes settle", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "pi-code-previews-write-abort-"));
+  try {
+    let resolveWriteStarted!: () => void;
+    const writeStarted = new Promise<void>((resolve) => {
+      resolveWriteStarted = resolve;
+    });
+
+    let resolveReleaseWrite!: () => void;
+    const releaseWrite = new Promise<void>((resolve) => {
+      resolveReleaseWrite = resolve;
+    });
+
+    vi.mocked(writeFile).mockImplementation(async () => {
+      resolveWriteStarted();
+      await releaseWrite;
+    });
+    vi.mocked(mkdir).mockResolvedValue(undefined);
+    vi.mocked(readExistingFileForPreview).mockResolvedValue({
+      kind: "content",
+      content: "before",
+    });
+
+    const controller = new AbortController();
+    const firstPromise = executeWriteWithPreview("target.txt", "after", dir, controller.signal);
+
+    await writeStarted;
+    controller.abort();
+
+    let secondAcquired = false;
+    const secondMutation = withFileMutationQueue(
+      resolvePreviewPath("target.txt", dir),
+      async () => {
+        secondAcquired = true;
+      },
+    );
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    assert.equal(secondAcquired, false);
+
+    resolveReleaseWrite();
+    await assert.rejects(firstPromise, { message: "Operation aborted" });
+    await secondMutation;
+    assert.equal(secondAcquired, true);
+
+    assert.equal(vi.mocked(mkdir).mock.calls.length, 1);
+    assert.equal(vi.mocked(writeFile).mock.calls.length, 1);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/src/write/preview-execution.ts
+++ b/src/write/preview-execution.ts
@@ -29,49 +29,40 @@ export async function executeWriteWithPreview(
   );
 }
 
-function executeWriteWithPreviewLock(
+function throwIfAborted(signal: AbortSignal | undefined, aborted: boolean): void {
+  if (aborted || signal?.aborted) throw new Error("Operation aborted");
+}
+
+async function executeWriteWithPreviewLock(
   path: string,
   content: string,
   cwd: string,
   absolutePath: string,
   signal: AbortSignal | undefined,
-) {
-  return new Promise<{
-    content: Array<{ type: "text"; text: string }>;
-    details: CodePreviewBeforeWriteDetails;
-  }>((resolve, reject) => {
-    if (signal?.aborted) {
-      reject(new Error("Operation aborted"));
-      return;
-    }
-    let aborted = false;
-    const onAbort = () => {
-      aborted = true;
-      reject(new Error("Operation aborted"));
+): Promise<{
+  content: Array<{ type: "text"; text: string }>;
+  details: CodePreviewBeforeWriteDetails;
+}> {
+  if (signal?.aborted) throw new Error("Operation aborted");
+  let aborted = false;
+  const onAbort = () => {
+    aborted = true;
+  };
+  signal?.addEventListener("abort", onAbort, { once: true });
+  try {
+    const before = await readExistingFileForPreview(path, cwd, content);
+    throwIfAborted(signal, aborted);
+    await mkdir(dirname(absolutePath), { recursive: true });
+    throwIfAborted(signal, aborted);
+    await writeFile(absolutePath, content, "utf-8");
+    throwIfAborted(signal, aborted);
+    return {
+      content: [{ type: "text", text: `Successfully wrote ${content.length} bytes to ${path}` }],
+      details: { codePreviewBeforeWrite: before },
     };
-    signal?.addEventListener("abort", onAbort, { once: true });
-
-    (async () => {
-      try {
-        const before = await readExistingFileForPreview(path, cwd, content);
-        if (aborted) return;
-        await mkdir(dirname(absolutePath), { recursive: true });
-        if (aborted) return;
-        await writeFile(absolutePath, content, "utf-8");
-        if (aborted) return;
-        signal?.removeEventListener("abort", onAbort);
-        resolve({
-          content: [
-            { type: "text", text: `Successfully wrote ${content.length} bytes to ${path}` },
-          ],
-          details: { codePreviewBeforeWrite: before },
-        });
-      } catch (error) {
-        signal?.removeEventListener("abort", onAbort);
-        if (!aborted) reject(error);
-      }
-    })();
-  });
+  } finally {
+    signal?.removeEventListener("abort", onAbort);
+  }
 }
 
 export function withCodePreviewBeforeWrite<T extends { details?: unknown }>(


### PR DESCRIPTION
## Summary
- fix the diff background spec so typecheck/lint pass
- add a regression test for aborting write previews while the underlying write is still in flight
- keep the file mutation queue locked until in-flight write preview filesystem work reaches a safe point

## Verification
- npm run typecheck
- npm run lint
- npm run format:check
- npm test -- src/write/preview-execution.spec.ts
- npm test
- npm run build
- npm run check

Plan: 001-restore-write-abort-verification