### PR TITLE
fix: refresh code preview tools for session cwd

### DIFF
--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -9,7 +9,7 @@ import { registerToolRenderers } from "../tool-renderers/registration";
 
 export async function codePreviews(pi: ExtensionAPI) {
   await loadCodePreviewSettings();
-  const registeredTools = new Set<CodePreviewToolName>();
+  const registeredToolSignatures = new Map<CodePreviewToolName, string>();
   const activatedTools = new Set<CodePreviewToolName>();
 
   registerHealthCommand(pi);
@@ -19,6 +19,6 @@ export async function codePreviews(pi: ExtensionAPI) {
     await loadCodePreviewSettings(ctx.cwd);
     if (codePreviewSettings.syntaxHighlighting)
       void initializeShiki(codePreviewSettings.shikiTheme);
-    registerToolRenderers(pi, ctx.cwd, { registeredTools, activatedTools });
+    registerToolRenderers(pi, ctx.cwd, { registeredToolSignatures, activatedTools });
   });
 }

--- a/src/tool-renderers/registration.spec.ts
+++ b/src/tool-renderers/registration.spec.ts
@@ -33,8 +33,61 @@ test("renderer registration activates enabled preview tool overrides", () => {
   assert.equal(formatActiveCodePreviewTools(), "grep, find, ls");
 });
 
+test("renderer registration does not duplicate same cwd and option signature", () => {
+  process.env.CODE_PREVIEW_TOOLS = "read";
+  const registered: Array<{ name: string }> = [];
+  const registeredToolSignatures = new Map<CodePreviewToolName, string>();
+  const pi = { registerTool: (tool: unknown) => registered.push(tool as { name: string }) };
+  const toolOptions = { read: { autoResizeImages: false } };
+
+  registerToolRenderers(pi as never, "/tmp/project", { registeredToolSignatures, toolOptions });
+  registerToolRenderers(pi as never, "/tmp/project", { registeredToolSignatures, toolOptions });
+
+  assert.deepEqual(
+    registered.map((tool) => tool.name),
+    ["read"],
+  );
+});
+
+test("renderer registration refreshes wrappers when cwd changes", () => {
+  process.env.CODE_PREVIEW_TOOLS = "read";
+  const registered: Array<{ name: string }> = [];
+  const registeredToolSignatures = new Map<CodePreviewToolName, string>();
+  const pi = { registerTool: (tool: unknown) => registered.push(tool as { name: string }) };
+  const toolOptions = { read: { autoResizeImages: false } };
+
+  registerToolRenderers(pi as never, "/tmp/project-a", { registeredToolSignatures, toolOptions });
+  registerToolRenderers(pi as never, "/tmp/project-b", { registeredToolSignatures, toolOptions });
+
+  assert.deepEqual(
+    registered.map((tool) => tool.name),
+    ["read", "read"],
+  );
+});
+
+test("renderer registration refreshes wrappers when builtin options change", () => {
+  process.env.CODE_PREVIEW_TOOLS = "bash";
+  const registered: Array<{ name: string }> = [];
+  const registeredToolSignatures = new Map<CodePreviewToolName, string>();
+  const pi = { registerTool: (tool: unknown) => registered.push(tool as { name: string }) };
+
+  registerToolRenderers(pi as never, "/tmp/project", {
+    registeredToolSignatures,
+    toolOptions: { bash: { shellPath: "/bin/sh" } },
+  });
+  registerToolRenderers(pi as never, "/tmp/project", {
+    registeredToolSignatures,
+    toolOptions: { bash: { shellPath: "/bin/zsh" } },
+  });
+
+  assert.deepEqual(
+    registered.map((tool) => tool.name),
+    ["bash", "bash"],
+  );
+});
+
 test("renderer registration removes previously activated previews when disabled", () => {
-  const registeredTools = new Set<CodePreviewToolName>();
+  const registeredToolSignatures = new Map<CodePreviewToolName, string>();
   const activatedTools = new Set<CodePreviewToolName>();
   let activeTools = ["read", "bash"];
   const pi = {
@@ -47,7 +100,7 @@ test("renderer registration removes previously activated previews when disabled"
 
   process.env.CODE_PREVIEW_TOOLS = "grep";
   registerToolRenderers(pi as never, "/tmp/project", {
-    registeredTools,
+    registeredToolSignatures,
     activatedTools,
     toolOptions: {},
   });
@@ -56,7 +109,7 @@ test("renderer registration removes previously activated previews when disabled"
 
   process.env.CODE_PREVIEW_TOOLS = "none";
   registerToolRenderers(pi as never, "/tmp/project", {
-    registeredTools,
+    registeredToolSignatures,
     activatedTools,
     toolOptions: {},
   });
@@ -86,6 +139,7 @@ test("renderer registration does not remove tools that were already active", () 
 test("renderer registration skips tools already owned by another extension", () => {
   process.env.CODE_PREVIEW_TOOLS = "read,grep,write";
   const registered: Array<{ name: string }> = [];
+  const registeredToolSignatures = new Map<CodePreviewToolName, string>();
   registerToolRenderers(
     {
       getAllTools: () => [
@@ -126,6 +180,7 @@ test("renderer registration skips tools already owned by another extension", () 
       registerTool: (tool: unknown) => registered.push(tool as { name: string }),
     } as never,
     "/tmp/project",
+    { registeredToolSignatures },
   );
 
   assert.deepEqual(

--- a/src/tool-renderers/registration.ts
+++ b/src/tool-renderers/registration.ts
@@ -12,7 +12,7 @@ import { registerRead } from "./read";
 import { registerWrite } from "./write";
 
 export interface RegisterToolRenderersOptions {
-  registeredTools?: Set<CodePreviewToolName>;
+  registeredToolSignatures?: Map<CodePreviewToolName, string>;
   activatedTools?: Set<CodePreviewToolName>;
   toolOptions?: BuiltinToolOptions;
 }
@@ -33,6 +33,19 @@ const TOOL_RENDERER_REGISTRATIONS = {
   ls: (pi, cwd) => registerLs(pi, cwd),
 } satisfies Record<CodePreviewToolName, ToolRendererRegistration>;
 
+function registrationSignature(
+  tool: CodePreviewToolName,
+  cwd: string,
+  options: BuiltinToolOptions,
+): string {
+  return JSON.stringify({
+    tool,
+    cwd,
+    bash: options.bash ?? null,
+    read: options.read ?? null,
+  });
+}
+
 export function registerToolRenderers(
   pi: ExtensionAPI,
   cwd: string,
@@ -46,20 +59,23 @@ export function registerToolRenderers(
 
   for (const tool of ALL_CODE_PREVIEW_TOOLS) {
     if (!enabledTools.has(tool)) continue;
-    if (options.registeredTools?.has(tool)) {
+
+    const signature = registrationSignature(tool, cwd, toolOptions);
+    const previousSignature = options.registeredToolSignatures?.get(tool);
+    if (previousSignature === signature) {
       setCodePreviewToolStatus(tool, { state: "active" });
       activePreviewTools.add(tool);
       continue;
     }
 
     const existing = existingTools.get(tool);
-    if (existing && existing.sourceInfo.source !== "builtin") {
+    if (!previousSignature && existing && existing.sourceInfo.source !== "builtin") {
       setCodePreviewToolStatus(tool, { state: "skipped-conflict", owner: existing.sourceInfo });
       continue;
     }
 
     TOOL_RENDERER_REGISTRATIONS[tool](pi, cwd, toolOptions);
-    options.registeredTools?.add(tool);
+    options.registeredToolSignatures?.set(tool, signature);
     activePreviewTools.add(tool);
     setCodePreviewToolStatus(tool, { state: "active" });
   }


### PR DESCRIPTION
## Summary
- replace one-time registered-tool tracking with cwd/options signatures
- re-register code-preview wrappers when session cwd or builtin bash/read options change
- add regression coverage for same-signature dedupe, cwd refresh, and option refresh

## Verification
- npm test -- src/tool-renderers/registration.spec.ts src/tools/builtin-options.spec.ts
- npm run typecheck
- npm run lint
- npm run format:check
- npm test
- npm run build
- npm run check

## Notes
- Stacked on PR #15 / branch `advisor/001-restore-write-abort-verification` because Plan 002 depends on Plan 001.

Plan: 002-reregister-cwd-bound-tools