### PR TITLE
fix: render standard edit result diff lines

### DIFF
--- a/src/diff/index.spec.ts
+++ b/src/diff/index.spec.ts
@@ -11,6 +11,7 @@ import {
   summarizeDiff,
 } from "./index";
 import { createDiffBackgroundResolver, diffLineBg } from "./background";
+import { parseDiffLine } from "./parse";
 import { wordEmphasisTelemetry } from "../testing/word-emphasis-telemetry";
 import { changedRanges, changedRangesWithConfidence } from "./word/emphasis";
 
@@ -42,6 +43,23 @@ test("summarizeDiff classifies replacements, insertions, and deletions by change
   assert.equal(withExtraLines.insertions, 1);
   assert.equal(withExtraLines.deletions, 1);
   assert.equal(withExtraLines.hunks, 2);
+});
+
+test("parseDiffLine accepts standard body lines but not file headers", () => {
+  assert.deepEqual(parseDiffLine("-old"), { kind: "-", lineNumber: "", content: "old" });
+  assert.deepEqual(parseDiffLine("+new"), { kind: "+", lineNumber: "", content: "new" });
+  assert.deepEqual(parseDiffLine(" context"), {
+    kind: " ",
+    lineNumber: "",
+    content: "context",
+  });
+  assert.deepEqual(parseDiffLine("+  indented"), {
+    kind: "+",
+    lineNumber: "",
+    content: "  indented",
+  });
+  assert.equal(parseDiffLine("--- a/file.ts"), null);
+  assert.equal(parseDiffLine("+++ b/file.ts"), null);
 });
 
 test("plain diff escapes terminal control characters", () => {

--- a/src/diff/parse.ts
+++ b/src/diff/parse.ts
@@ -15,10 +15,16 @@ function normalizedDiffLineNumber(line: ParsedDiffLine | null): string {
 }
 
 export function parseDiffLine(line: string): ParsedDiffLine | null {
-  const match = line.match(/^([+\- ])(\s*\d*)\s(.*)$/);
-  if (!match) return null;
-  const kind = match[1] as ParsedDiffLine["kind"];
-  return { kind, lineNumber: match[2], content: match[3] };
+  const numbered = line.match(/^([+\- ])(\s*\d+)\s(.*)$/);
+  if (numbered) {
+    const kind = numbered[1] as ParsedDiffLine["kind"];
+    return { kind, lineNumber: numbered[2], content: numbered[3] };
+  }
+
+  if (line.startsWith("+++") || line.startsWith("---")) return null;
+  const prefix = line[0];
+  if (prefix !== "+" && prefix !== "-" && prefix !== " ") return null;
+  return { kind: prefix, lineNumber: "", content: line.slice(1) };
 }
 
 export function isAddedDiffLine(line: ParsedDiffLine | null): line is AddedDiffLine {

--- a/src/tool-renderers/integration/edit-write.spec.ts
+++ b/src/tool-renderers/integration/edit-write.spec.ts
@@ -279,17 +279,26 @@ test("registered edit renderer hides diff previews until expanded", () => {
     assert.match(collapsedResult, /expand/);
     assert.doesNotMatch(collapsedResult, /const value = 2/);
 
+    const diffTheme = {
+      ...testTheme(),
+      fg: (key: string, text: string) => {
+        if (key === "toolDiffRemoved") return `REMOVED<${text}>`;
+        if (key === "toolDiffAdded") return `ADDED<${text}>`;
+        return text;
+      },
+    };
     const expandedResult = stripAnsi(
       renderComponent(
         edit.renderResult(
           result,
           { expanded: true, isPartial: false },
-          testTheme(),
+          diffTheme,
           createToolRenderContext({ args: { path: "src/a.ts" } }),
         ),
       ),
     );
-    assert.match(expandedResult, /const value = 2/);
+    assert.match(expandedResult, /REMOVED<-\s*│ >const value = 1;/);
+    assert.match(expandedResult, /ADDED<\+\s*│ >const value = 2;/);
   } finally {
     setCodePreviewSettings(previousSettings);
   }


### PR DESCRIPTION
## Summary
- teach diff parsing to accept standard unified-diff body lines like `-old` and `+new`
- keep `---` / `+++` file headers on the separator path
- add parser and edit-renderer integration coverage for standard edit result diffs

## Verification
- npm test -- src/diff/index.spec.ts src/tool-renderers/integration/edit-write.spec.ts
- npm run typecheck
- npm run lint
- npm run format:check
- npm test
- npm run build
- npm run check

## Notes
- Stacked on PR #15 / branch `advisor/001-restore-write-abort-verification` because Plan 003 depends on Plan 001.

Plan: 003-render-standard-edit-diffs