### PR TITLE
fix: avoid persisting write preview contents

### DIFF
--- a/src/shared/terminal-text.spec.ts
+++ b/src/shared/terminal-text.spec.ts
@@ -1,8 +1,13 @@
 import assert from "node:assert/strict";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { test } from "vitest";
-import { injectVisibleRanges, wrapAnsiToWidth } from "./terminal-text";
+import { escapeControlChars, injectVisibleRanges, wrapAnsiToWidth } from "./terminal-text";
 import { stripAnsi } from "../testing/render";
+
+test("control escaping neutralizes C1 terminal controls", () => {
+  assert.equal(escapeControlChars("ok \u009b31mred"), "ok �31mred");
+  assert.equal(escapeControlChars("title\u009dafter"), "title�after");
+});
 
 test("visible-range injection preserves SGR foreground resets", () => {
   const highlighted = injectVisibleRanges("ab\x1b[31mc\x1b[39mde", [[1, 4]], {

--- a/src/shared/terminal-text.ts
+++ b/src/shared/terminal-text.ts
@@ -4,7 +4,7 @@ export function escapeControlChars(text: string): string {
   return text
     .replace(/\x1b/g, "␛")
     .replace(/\r/g, "␍")
-    .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "�");
+    .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f\x80-\x9f]/g, "�");
 }
 
 const ANSI_RE = /\x1b\[[0-9;]*[A-Za-z]/g;

--- a/src/tool-renderers/integration/edit-write.spec.ts
+++ b/src/tool-renderers/integration/edit-write.spec.ts
@@ -171,6 +171,32 @@ test("registered write renderer hides code previews until expanded", () => {
   }
 });
 
+test("registered write renderer does not label redacted previous content as a new file", () => {
+  process.env.CODE_PREVIEW_TOOLS = "write";
+  const write = findRenderer(registerRenderers(), "write");
+  assert.ok(write.renderResult);
+
+  const rendered = stripAnsi(
+    renderComponent(
+      write.renderResult(
+        {
+          content: [{ type: "text", text: "ok" }],
+          details: { codePreviewBeforeWrite: { kind: "content", byteLength: 6 } },
+        },
+        { expanded: true, isPartial: false },
+        testTheme(),
+        createToolRenderContext({
+          args: { path: "src/a.ts", content: "after" },
+          toolCallId: "tool-redacted-missing-cache",
+        }),
+      ),
+    ),
+  );
+
+  assert.match(rendered, /previous content unavailable/);
+  assert.doesNotMatch(rendered, /New file/);
+});
+
 test("registered write renderer distinguishes blank-only content from empty content", () => {
   process.env.CODE_PREVIEW_TOOLS = "write";
   const write = findRenderer(registerRenderers(), "write");
@@ -214,8 +240,9 @@ test("registered write execute snapshots previous content inside the file mutati
     });
     await acquiredPromise;
 
+    const toolCallId = "tool-queue";
     const executePromise = write.execute(
-      "tool-1",
+      toolCallId,
       { path: "target.txt", content: "final" },
       undefined,
       undefined,
@@ -224,10 +251,26 @@ test("registered write execute snapshots previous content inside the file mutati
     await delay(10);
     release();
     const [result] = await Promise.all([executePromise, queuedMutation]);
-    const details = (result as { details?: Record<string, unknown> }).details;
-    const before = details?.codePreviewBeforeWrite as { content?: string } | undefined;
+    const details = (result as { details?: unknown }).details;
 
-    assert.equal(before?.content, "queued");
+    assert.doesNotMatch(JSON.stringify(details), /queued/);
+
+    const rendered = stripAnsi(
+      renderComponent(
+        write.renderResult!(
+          result as never,
+          { expanded: true, isPartial: false },
+          testTheme(),
+          createToolRenderContext({
+            args: { path: "target.txt", content: "final" },
+            isPartial: false,
+            toolCallId,
+          }),
+        ),
+      ),
+    );
+    assert.match(rendered, /queued/);
+    assert.match(rendered, /final/);
     assert.equal(await readFile(file, "utf8"), "final");
   } finally {
     await rm(dir, { recursive: true, force: true });

--- a/src/tool-renderers/write.ts
+++ b/src/tool-renderers/write.ts
@@ -51,7 +51,7 @@ export function registerWrite(pi: ExtensionAPI, cwd: string) {
         const result = await originalWrite.execute(toolCallId, params, signal, onUpdate, ctx);
         return withCodePreviewBeforeWrite(result, before);
       }
-      return executeWriteWithPreview(path, content, cwd, signal);
+      return executeWriteWithPreview(toolCallId, path, content, cwd, signal);
     },
 
     renderCall(args, theme, context) {
@@ -108,8 +108,9 @@ export function registerWrite(pi: ExtensionAPI, cwd: string) {
         const path = getPathArg(renderContext.args);
         const content =
           typeof renderContext.args?.content === "string" ? renderContext.args.content : "";
-        const before = getCodePreviewBeforeWrite(result.details);
+        const before = getCodePreviewBeforeWrite(renderContext.toolCallId, result.details);
         const beforeContent = getObjectValue(before, "content");
+        const beforeKind = getObjectValue(before, "kind");
         const skipReason = getWriteDiffSkipReason(before, content);
         if (skipReason)
           return new Text(
@@ -160,6 +161,13 @@ export function registerWrite(pi: ExtensionAPI, cwd: string) {
         }
         if (typeof beforeContent === "string")
           return new Text(theme.fg("muted", "✓ Write applied · no changes"), 0, 0);
+        if (beforeKind === "content")
+          return new Text(
+            theme.fg("success", "✓ Write applied") +
+              theme.fg("muted", " · previous content unavailable"),
+            0,
+            0,
+          );
         return new Text(
           theme.fg("success", `✓ New file (${countLabel(countContentLines(content), "line")})`),
           0,

--- a/src/write/preview-execution.spec.ts
+++ b/src/write/preview-execution.spec.ts
@@ -42,7 +42,13 @@ test("aborted writes keep the file mutation queue locked until in-flight writes 
     });
 
     const controller = new AbortController();
-    const firstPromise = executeWriteWithPreview("target.txt", "after", dir, controller.signal);
+    const firstPromise = executeWriteWithPreview(
+      "tool-1",
+      "target.txt",
+      "after",
+      dir,
+      controller.signal,
+    );
 
     await writeStarted;
     controller.abort();

--- a/src/write/preview-execution.ts
+++ b/src/write/preview-execution.ts
@@ -6,18 +6,31 @@ import { getObjectValue } from "../shared/objects";
 import { readExistingFileForPreview, type ExistingFilePreview } from "./diff";
 
 const CODE_PREVIEW_BEFORE_WRITE_DETAIL = "codePreviewBeforeWrite";
+const MAX_BEFORE_WRITE_CACHE_ENTRIES = 64;
 
 export type CodePreviewBeforeWrite = ExistingFilePreview | undefined;
 
+type RedactedCodePreviewBeforeWrite =
+  | Exclude<ExistingFilePreview, { kind: "content" }>
+  | { kind: "content"; byteLength: number }
+  | undefined;
+
 export type CodePreviewBeforeWriteDetails = {
-  codePreviewBeforeWrite: CodePreviewBeforeWrite;
+  codePreviewBeforeWrite: RedactedCodePreviewBeforeWrite;
 };
 
-export function getCodePreviewBeforeWrite(details: unknown): unknown {
+const beforeWriteCache = new Map<string, CodePreviewBeforeWrite>();
+
+export function getCodePreviewBeforeWrite(
+  toolCallId: string | undefined,
+  details: unknown,
+): unknown {
+  if (toolCallId && beforeWriteCache.has(toolCallId)) return beforeWriteCache.get(toolCallId);
   return getObjectValue(details, CODE_PREVIEW_BEFORE_WRITE_DETAIL);
 }
 
 export async function executeWriteWithPreview(
+  toolCallId: string,
   path: string,
   content: string,
   cwd: string,
@@ -25,8 +38,23 @@ export async function executeWriteWithPreview(
 ) {
   const absolutePath = resolvePreviewPath(path, cwd);
   return withFileMutationQueue(absolutePath, () =>
-    executeWriteWithPreviewLock(path, content, cwd, absolutePath, signal),
+    executeWriteWithPreviewLock(toolCallId, path, content, cwd, absolutePath, signal),
   );
+}
+
+function rememberCodePreviewBeforeWrite(toolCallId: string, before: CodePreviewBeforeWrite): void {
+  beforeWriteCache.delete(toolCallId);
+  if (before !== undefined) beforeWriteCache.set(toolCallId, before);
+  while (beforeWriteCache.size > MAX_BEFORE_WRITE_CACHE_ENTRIES) {
+    const oldest = beforeWriteCache.keys().next().value;
+    if (oldest === undefined) break;
+    beforeWriteCache.delete(oldest);
+  }
+}
+
+function redactedBeforeWriteDetail(before: CodePreviewBeforeWrite): RedactedCodePreviewBeforeWrite {
+  if (!before || before.kind !== "content") return before;
+  return { kind: "content", byteLength: Buffer.byteLength(before.content, "utf8") };
 }
 
 function throwIfAborted(signal: AbortSignal | undefined, aborted: boolean): void {
@@ -34,6 +62,7 @@ function throwIfAborted(signal: AbortSignal | undefined, aborted: boolean): void
 }
 
 async function executeWriteWithPreviewLock(
+  toolCallId: string,
   path: string,
   content: string,
   cwd: string,
@@ -56,9 +85,10 @@ async function executeWriteWithPreviewLock(
     throwIfAborted(signal, aborted);
     await writeFile(absolutePath, content, "utf-8");
     throwIfAborted(signal, aborted);
+    rememberCodePreviewBeforeWrite(toolCallId, before);
     return {
       content: [{ type: "text", text: `Successfully wrote ${content.length} bytes to ${path}` }],
-      details: { codePreviewBeforeWrite: before },
+      details: { codePreviewBeforeWrite: redactedBeforeWriteDetail(before) },
     };
   } finally {
     signal?.removeEventListener("abort", onAbort);
@@ -70,5 +100,8 @@ export function withCodePreviewBeforeWrite<T extends { details?: unknown }>(
   before: CodePreviewBeforeWrite,
 ): T & { details: Record<string, unknown> } {
   const details = result.details && typeof result.details === "object" ? result.details : {};
-  return { ...result, details: { ...details, [CODE_PREVIEW_BEFORE_WRITE_DETAIL]: before } };
+  return {
+    ...result,
+    details: { ...details, [CODE_PREVIEW_BEFORE_WRITE_DETAIL]: redactedBeforeWriteDetail(before) },
+  };
 }


### PR DESCRIPTION
## Summary
- escape C1 terminal control characters in preview text
- keep raw pre-write contents in a bounded in-memory cache keyed by tool call id
- return redacted write-before metadata in result details instead of serializing raw overwritten content
- render a safe fallback for redacted/persisted write results when cached content is unavailable

## Verification
- npm test -- src/shared/terminal-text.spec.ts src/write/diff.spec.ts src/tool-renderers/integration/edit-write.spec.ts
- npm test -- src/write/preview-execution.spec.ts
- npm run typecheck
- npm run lint
- npm run format:check
- npm test
- npm run build
- npm run check

## Notes
- Stacked on PR #15 / branch `advisor/001-restore-write-abort-verification` because Plan 004 depends on Plan 001.

Plan: 004-harden-terminal-and-write-privacy