### PR TITLE
FIX: make word emphasis readable on light themes

### DIFF
--- a/src/diff/index.spec.ts
+++ b/src/diff/index.spec.ts
@@ -127,15 +127,24 @@ test("word emphasis pairs the most similar lines inside change blocks", () => {
     "-1 const trimmed = line.trim();\n+1 const safeLine = escapeControlChars(line);\n+2 const trimmed = safeLine.trim();";
   const rendered = renderSyntaxHighlightedDiff(diff, undefined, testTheme(), 3).split("\n");
   assert.doesNotMatch(rendered[1] ?? "", /\x1b\[48;2;64;132;82m/);
-  assert.match(rendered[2] ?? "", /\x1b\[48;2;64;132;82m\x1b\[1msafeLine/);
-  assert.match(rendered[0] ?? "", /\x1b\[48;2;148;62;70m\x1b\[1mline/);
+  assert.match(rendered[2] ?? "", /\x1b\[48;2;64;132;82msafeLine/);
+  assert.match(rendered[0] ?? "", /\x1b\[48;2;148;62;70mline/);
+});
+
+test("word emphasis uses readable backgrounds with light syntax themes", () => {
+  setCodePreviewSettings({ ...codePreviewSettings, shikiTheme: "github-light" });
+  const diff = "-1 const value = oldValue;\n+1 const value = newValue;";
+  const rendered = renderSyntaxHighlightedDiff(diff, undefined, testTheme(), 2);
+  assert.match(rendered, /\x1b\[48;2;216;182;182mold/);
+  assert.match(rendered, /\x1b\[48;2;194;209;194mnew/);
+  assert.doesNotMatch(rendered, /\x1b\[48;2;(?:148;62;70|64;132;82)m/);
 });
 
 test("word emphasis marks low-overlap one-to-one changed pairs instead of skipping them", () => {
   const diff = "-1 out.push(pair.removed, pair.added);\n+1 block.push(next);";
   const rendered = renderSyntaxHighlightedDiff(diff, undefined, testTheme(), 2).split("\n");
-  assert.match(rendered[0] ?? "", /\x1b\[48;2;148;62;70m\x1b\[1mout/);
-  assert.match(rendered[1] ?? "", /\x1b\[48;2;64;132;82m\x1b\[1mblock/);
+  assert.match(rendered[0] ?? "", /\x1b\[48;2;148;62;70mout/);
+  assert.match(rendered[1] ?? "", /\x1b\[48;2;64;132;82mblock/);
 });
 
 test("word emphasis uses compound identifier parts when pairing changed lines", () => {
@@ -145,8 +154,8 @@ test("word emphasis uses compound identifier parts when pairing changed lines", 
     "+2 return renderPreview(input);",
   ].join("\n");
   const rendered = renderSyntaxHighlightedDiff(diff, undefined, testTheme(), 3).split("\n");
-  assert.match(rendered[0] ?? "", /\x1b\[48;2;148;62;70m\x1b\[1mread/);
-  assert.match(rendered[1] ?? "", /\x1b\[48;2;64;132;82m\x1b\[1medit/);
+  assert.match(rendered[0] ?? "", /\x1b\[48;2;148;62;70mread/);
+  assert.match(rendered[1] ?? "", /\x1b\[48;2;64;132;82medit/);
   assert.doesNotMatch(rendered[2] ?? "", /\x1b\[48;2;64;132;82m/);
 });
 
@@ -195,10 +204,10 @@ test("word emphasis pairs high-confidence reordered lines", () => {
     "+2 const alphaResult = computeAlpha(next);",
   ].join("\n");
   const rendered = renderSyntaxHighlightedDiff(diff, undefined, testTheme(), 4).split("\n");
-  assert.match(rendered[0] ?? "", /\x1b\[48;2;148;62;70m\x1b\[1minput/);
-  assert.match(rendered[1] ?? "", /\x1b\[48;2;148;62;70m\x1b\[1mprevious/);
-  assert.match(rendered[2] ?? "", /\x1b\[48;2;64;132;82m\x1b\[1mcurrent/);
-  assert.match(rendered[3] ?? "", /\x1b\[48;2;64;132;82m\x1b\[1mnext/);
+  assert.match(rendered[0] ?? "", /\x1b\[48;2;148;62;70minput/);
+  assert.match(rendered[1] ?? "", /\x1b\[48;2;148;62;70mprevious/);
+  assert.match(rendered[2] ?? "", /\x1b\[48;2;64;132;82mcurrent/);
+  assert.match(rendered[3] ?? "", /\x1b\[48;2;64;132;82mnext/);
 });
 
 test("word emphasis narrows compound identifier changes to changed segments", () => {
@@ -269,9 +278,9 @@ test("word emphasis skips low-confidence positional pairs inside larger blocks",
     "+2 renderCompletelyDifferentScreen();",
   ].join("\n");
   const rendered = renderSyntaxHighlightedDiff(diff, undefined, testTheme(), 4).split("\n");
-  assert.match(rendered[0] ?? "", /\x1b\[48;2;148;62;70m\x1b\[1mitems/);
+  assert.match(rendered[0] ?? "", /\x1b\[48;2;148;62;70mitems/);
   assert.doesNotMatch(rendered[1] ?? "", /\x1b\[48;2;148;62;70m/);
-  assert.match(rendered[2] ?? "", /\x1b\[48;2;64;132;82m\x1b\[1mnext/);
+  assert.match(rendered[2] ?? "", /\x1b\[48;2;64;132;82mnext/);
   assert.doesNotMatch(rendered[3] ?? "", /\x1b\[48;2;64;132;82m/);
 });
 
@@ -306,7 +315,7 @@ test("smart word emphasis suppresses low-signal wrapper syntax", () => {
 
   setCodePreviewSettings({ ...codePreviewSettings, wordEmphasis: "all" });
   const all = renderSyntaxHighlightedDiff(diff, undefined, testTheme(), 2);
-  assert.match(all, /\x1b\[48;2;148;62;70m\x1b\[1m\.map/);
+  assert.match(all, /\x1b\[48;2;148;62;70m\.map/);
 });
 
 test("word emphasis can be disabled", () => {
@@ -331,8 +340,8 @@ test("word emphasis ranges stay aligned when indentation changes", () => {
   const diff =
     "-1 \tconst next = parseDiffLine(lines[i + 1]!);\n+1 \t\tconst next = parseDiffLine(lines[end]!);";
   const rendered = renderSyntaxHighlightedDiff(diff, undefined, testTheme(), 2).split("\n");
-  assert.match(rendered[0] ?? "", /lines\[\x1b\[48;2;148;62;70m\x1b\[1mi \+ 1/);
-  assert.match(rendered[1] ?? "", /lines\[\x1b\[48;2;64;132;82m\x1b\[1mend/);
+  assert.match(rendered[0] ?? "", /lines\[\x1b\[48;2;148;62;70mi \+ 1/);
+  assert.match(rendered[1] ?? "", /lines\[\x1b\[48;2;64;132;82mend/);
 });
 
 test("word emphasis highlights long shared lines with appended text", () => {
@@ -342,7 +351,7 @@ test("word emphasis highlights long shared lines with appended text", () => {
   assert.doesNotMatch(rendered[0] ?? "", /\x1b\[48;2;148;62;70m/);
   assert.match(
     rendered[1] ?? "",
-    /\x1b\[48;2;64;132;82m\x1b\[1m\. Project settings override global settings/,
+    /\x1b\[48;2;64;132;82m\. Project settings override global settings/,
   );
 });
 
@@ -358,8 +367,8 @@ test("word emphasis is applied synchronously for large changed lines", () => {
     () => invalidations++,
   );
   assert.equal(invalidations, 0);
-  assert.match(rendered, /\x1b\[48;2;148;62;70m\x1b\[1mold/);
-  assert.match(rendered, /\x1b\[48;2;64;132;82m\x1b\[1mnew/);
+  assert.match(rendered, /\x1b\[48;2;148;62;70mold/);
+  assert.match(rendered, /\x1b\[48;2;64;132;82mnew/);
 });
 
 test("word range emphasis returns changed spans for unrelated token-heavy lines", () => {

--- a/src/diff/word/emphasis-golden.spec.ts
+++ b/src/diff/word/emphasis-golden.spec.ts
@@ -5,8 +5,8 @@ import { codePreviewSettings, setCodePreviewSettings } from "../../settings/inde
 import { stripAnsi, testTheme } from "../../testing/render";
 import { wordEmphasisGoldenCases } from "./fixtures/emphasis-golden";
 
-const WORD_EMPHASIS_OPEN = /\x1b\[48;2;(?:64;132;82|148;62;70)m\x1b\[1m/g;
-const WORD_EMPHASIS_CLOSE = "\x1b[22m\x1b[49m";
+const WORD_EMPHASIS_OPEN = /\x1b\[48;2;(?:64;132;82|148;62;70)m/g;
+const WORD_EMPHASIS_CLOSE = "\x1b[49m";
 
 let previousCodePreviewSettings = { ...codePreviewSettings };
 

--- a/src/diff/word/line-emphasis.ts
+++ b/src/diff/word/line-emphasis.ts
@@ -1,8 +1,12 @@
+import { bundledThemesInfo } from "shiki";
+import { codePreviewSettings } from "../../settings/index";
 import type { DiffWordEmphasis } from "../../settings/types";
 import { injectVisibleRanges } from "../../shared/terminal-text";
 import type { ParsedDiffLine } from "../parse";
 import { analyzeChangedLineBlock } from "./change-block";
 import { shouldEmphasizeChangedPair } from "./emphasis";
+
+const shikiThemeTypes = new Map(bundledThemesInfo.map((theme) => [theme.id, theme.type]));
 
 export function changedLineEmphasis(
   block: ParsedDiffLine[],
@@ -31,7 +35,7 @@ export function emphasizeChangedSpans(
     line.slice(0, codeStart) +
     injectVisibleRanges(line.slice(codeStart), ranges, {
       open: wordEmphasis(kind),
-      close: "\x1b[22m\x1b[49m",
+      close: "\x1b[49m",
       reopenAfterSgr: (sequence) => sequence === "\x1b[39m" || sequence === "\x1b[22m",
     })
   );
@@ -50,5 +54,8 @@ function findCodeStart(line: string): number {
 }
 
 function wordEmphasis(kind: "add" | "remove"): string {
-  return kind === "add" ? "\x1b[48;2;64;132;82m\x1b[1m" : "\x1b[48;2;148;62;70m\x1b[1m";
+  if (shikiThemeTypes.get(codePreviewSettings.shikiTheme) === "light") {
+    return kind === "add" ? "\x1b[48;2;194;209;194m" : "\x1b[48;2;216;182;182m";
+  }
+  return kind === "add" ? "\x1b[48;2;64;132;82m" : "\x1b[48;2;148;62;70m";
 }


### PR DESCRIPTION
Use lighter word-emphasis backgrounds to fix "black text on dark bg" when the configured Shiki theme is light, keeping the existing dark-theme colors unchanged. Add a regression test for the light-theme highlight colors.

Before:
<img width="1114" height="572" alt="image" src="https://github.com/user-attachments/assets/4822c574-2358-4a92-9ad8-7fefa354d3f7" />

after
<img width="1088" height="528" alt="image" src="https://github.com/user-attachments/assets/c271e3c0-df18-42ee-ad17-c9e3b5da22d4" />
